### PR TITLE
Fixes ever-increasing counters

### DIFF
--- a/lib/twemproxy_exporter/counter.rb
+++ b/lib/twemproxy_exporter/counter.rb
@@ -3,17 +3,15 @@ module TwemproxyExporter
     def initialize(registry, name, desc)
       @counter = Prometheus::Client::Counter.new(name, desc)
       registry.register(@counter)
-      @last = 0
     end
 
     def count(value, labels = {})
-      if value >= @last
-        @counter.increment(labels, value - @last)
+      current = value(labels)
+      if value >= current
+        @counter.increment(labels, value - current)
       else
         @counter.increment(labels, value)
       end
-
-      @last = value
     end
 
     def value(labels = {})

--- a/lib/twemproxy_exporter/counter.rb
+++ b/lib/twemproxy_exporter/counter.rb
@@ -3,15 +3,17 @@ module TwemproxyExporter
     def initialize(registry, name, desc)
       @counter = Prometheus::Client::Counter.new(name, desc)
       registry.register(@counter)
+      @last_values = {}
     end
 
     def count(value, labels = {})
-      current = value(labels)
-      if value >= current
-        @counter.increment(labels, value - current)
+      last = @last_values[labels] || 0
+      if value >= last
+        @counter.increment(labels, value - last)
       else
         @counter.increment(labels, value)
       end
+      @last_values[labels] = value
     end
 
     def value(labels = {})

--- a/spec/twemproxy_exporter/counter_spec.rb
+++ b/spec/twemproxy_exporter/counter_spec.rb
@@ -1,28 +1,73 @@
 describe TwemproxyExporter::Counter do
-  before(:all) do
-    registry = Prometheus::Client.registry
-    @counter = TwemproxyExporter::Counter.new(registry, :test_total, "A test counter")
-  end
-
   context "#count" do
-    it "should only increase" do
-      expect do
-        @counter.count(5)
-      end.to change { @counter.value }.by(5)
+    context "without labels" do
+      before(:all) do
+        registry = Prometheus::Client.registry
+        @counter = TwemproxyExporter::Counter.new(registry, :test_total, "A test counter")
+      end
 
-      expect(@counter.send(:instance_variable_get, :@last)).to equal(5)
+      it "should only increase" do
+        expect do
+          @counter.count(5)
+        end.to change { @counter.value }.by(5)
 
-      expect do
-        @counter.count(4)
-      end.to change { @counter.value }.by(4)
+        expect do
+          @counter.count(5)
+        end.to change { @counter.value }.by(0)
 
-      expect(@counter.send(:instance_variable_get, :@last)).to equal(4)
+        expect do
+          @counter.count(0)
+        end.to change { @counter.value }.by(0)
 
-      expect do
-        @counter.count(6)
-      end.to change { @counter.value }.by(2)
+        expect do
+          @counter.count(6)
+        end.to change { @counter.value }.by(1)
 
-      expect(@counter.send(:instance_variable_get, :@last)).to equal(6)
+        expect do
+          @counter.count(10)
+        end.to change { @counter.value }.by(4)
+
+        @counter.value.should eq(10)
+      end
+    end
+
+    context "with labels" do
+      before(:all) do
+        registry = Prometheus::Client.registry
+        @counter = TwemproxyExporter::Counter.new(registry, :test_with_labels_total, "A test counter with labels")
+      end
+
+      it "should handle multiple labels independently" do
+        label_a = { server: 'A' }
+        label_b = { server: 'B' }
+
+        expect do
+          @counter.count(0, label_a)
+        end.to change { @counter.value(label_a) }.by(0)
+        expect do 
+          @counter.count(10, label_b)
+        end.to change { @counter.value(label_b) }.by(10)
+
+        # no change
+        expect do
+          @counter.count(0, label_a)
+        end.to change { @counter.value(label_a) }.by(0)
+        expect do 
+          @counter.count(10, label_b)
+        end.to change { @counter.value(label_b) }.by(0)
+
+        # label_b increases
+        expect do
+          @counter.count(0, label_a)
+        end.to change { @counter.value(label_a) }.by(0)
+        expect do 
+          @counter.count(15, label_b)
+        end.to change { @counter.value(label_b) }.by(5)
+
+        # final check of absolute values
+        @counter.value(label_a).should eq(0)
+        @counter.value(label_b).should eq(15)
+      end
     end
   end
 end

--- a/spec/twemproxy_exporter/counter_spec.rb
+++ b/spec/twemproxy_exporter/counter_spec.rb
@@ -1,22 +1,16 @@
 describe TwemproxyExporter::Counter do
   context "#count" do
     context "without labels" do
-      before(:all) do
-        registry = Prometheus::Client.registry
-        @counter = TwemproxyExporter::Counter.new(registry, :test_total, "A test counter")
-      end
-
       it "should only increase" do
+        registry = Prometheus::Client.registry
+        @counter = TwemproxyExporter::Counter.new(registry, :test_increase_total, "A test counter")
+
         expect do
           @counter.count(5)
         end.to change { @counter.value }.by(5)
 
         expect do
           @counter.count(5)
-        end.to change { @counter.value }.by(0)
-
-        expect do
-          @counter.count(0)
         end.to change { @counter.value }.by(0)
 
         expect do
@@ -29,15 +23,37 @@ describe TwemproxyExporter::Counter do
 
         @counter.value.should eq(10)
       end
+
+      it "handle upstream counter reset" do
+        registry = Prometheus::Client.registry
+        @counter = TwemproxyExporter::Counter.new(registry, :test_reset_total, "A test counter")
+
+        expect do
+          @counter.count(5)
+        end.to change { @counter.value }.by(5)
+
+        # upstream counter reset!
+        expect do
+          @counter.count(1)
+        end.to change { @counter.value }.by(1)
+
+        expect do
+          @counter.count(6)
+        end.to change { @counter.value }.by(5)
+
+        expect do
+          @counter.count(7)
+        end.to change { @counter.value }.by(1)
+
+        @counter.value.should eq(12)
+      end
     end
 
     context "with labels" do
-      before(:all) do
+      it "should handle multiple labels independently" do
         registry = Prometheus::Client.registry
         @counter = TwemproxyExporter::Counter.new(registry, :test_with_labels_total, "A test counter with labels")
-      end
 
-      it "should handle multiple labels independently" do
         label_a = { server: 'A' }
         label_b = { server: 'B' }
 


### PR DESCRIPTION
This fixes a bug where counters would grow by their current value, resulting in every-increasing counter values even if the underlying twemproxy counter shows no change.

The problem is that `Counter` objects are shared across labels, thus the `@last` value cannot be trusted.

### Example

Assume a single counter `requests` with `label_a` and `label_b`. Counter for `label_a` is zero in twemproxy, while counter for `label_b` is 10. Both do not change:

- During export we loop through the counters and labels
- If we hit the `requests` A counter first we will set `@last=0`
- Then we get to `requests` B counter on the same object (`@last` still zero) and increment by `10 - 0` (`value - @last`), even though there should have been no change