### PR TITLE
Update Dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ language: ruby
 rvm:
   - 2.2.2 # Oldest compatible Ruby
   - 2.3.1
-  - 2.4.0 # Most recent Ruby release
-before_install: gem install bundler -v 1.13.7
+  - 2.4.0
+  - 3.4.7 # Most recent Ruby release
+before_install: gem install bundler -v 2.7.2

--- a/lib/twemproxy_exporter/version.rb
+++ b/lib/twemproxy_exporter/version.rb
@@ -1,3 +1,3 @@
 module TwemproxyExporter
-  VERSION = "0.1.1"
+  VERSION = "0.2.1"
 end

--- a/twemproxy_exporter.gemspec
+++ b/twemproxy_exporter.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_runtime_dependency "prometheus-client", "~> 0.6.0"


### PR DESCRIPTION
This also updates the gem to version 0.2.1, which includes the bugfix from #4.

The dependency upgrades are largely irrelevant, but this should silence a few dependabot warnings.