### PR TITLE
Add label for proxy

### DIFF
--- a/lib/twemproxy_exporter/twemproxy.rb
+++ b/lib/twemproxy_exporter/twemproxy.rb
@@ -16,7 +16,8 @@ module TwemproxyExporter
     def count
       stats  = self.stats
       name   = stats['source']
-      labels = {twemproxy: name}
+      proxy  = "#{@host}:#{@port}"
+      labels = {twemproxy: name, proxy: proxy}
 
       @exporter.total_connections.count stats['total_connections'], labels
       @exporter.curr_connections.count  stats['curr_connections'],  labels
@@ -24,7 +25,7 @@ module TwemproxyExporter
 
       stats.each do |cluster, cinfo|
         next unless cinfo.is_a? Hash
-        labels = {twemproxy: name, cluster: cluster}
+        labels = {twemproxy: name, proxy: proxy, cluster: cluster}
 
         @exporter.fragments.count          cinfo['fragments'],          labels
         @exporter.forward_error.count      cinfo['forward_error'],      labels
@@ -35,7 +36,7 @@ module TwemproxyExporter
 
         cinfo.each do |server, sinfo|
           next unless sinfo.is_a? Hash
-          labels = {twemproxy: name, cluster: cluster, server: server}
+          labels = {twemproxy: name, proxy: proxy, cluster: cluster, server: server}
 
           @exporter.in_queue.count           sinfo['in_queue'],           labels
           @exporter.in_queue_bytes.count     sinfo['in_queue_bytes'],     labels

--- a/spec/twemproxy_exporter/exporter_spec.rb
+++ b/spec/twemproxy_exporter/exporter_spec.rb
@@ -1,7 +1,7 @@
 describe TwemproxyExporter::Exporter do
   let(:stats_file) { File.open("spec/fixtures/files/stats.json") }
   let(:config) { { "proxies" => ["localhost"] } }
-  let(:twemproxy_labels) { { twemproxy: "app-production-redis-twemproxy" } }
+  let(:twemproxy_labels) { { twemproxy: "app-production-redis-twemproxy", proxy: "localhost:22222" } }
   let(:cluster_labels) { twemproxy_labels.merge({ cluster: "app_persistent" }) }
 
   before do


### PR DESCRIPTION
I'm so sorry to pop up with another issue right away... While the previous fix worked on our dev deployment, and at first it looked good on our prod deployment, over time the prod deployment's metrics grew unexpectedly.

Some deployments may have multiple twemproxy processes on the same host, all of which are proxying the same clusters and servers. Similar to https://github.com/xavierholt/twemproxy_exporter/pull/4 we then run into issues, where a single counter may be shared across multiple proxies and count incorrectly. The label `twemproxy` is not sufficient in this case, because it comes from twemproxy's stats and is set to the current hostname (not configurable).

I contemplated using some kind of internal label to use as a discriminator. However, adding a new label for the actual underlying proxy is beneficial for people that have multiple proxies on the same host (but at the same it shouldn't be an issue for single proxy deployments). I didn't want to change the existing `twemproxy` label to avoid breaking backwards compatibility.